### PR TITLE
Make XDDE plan optional

### DIFF
--- a/custom_components/meteocat/__init__.py
+++ b/custom_components/meteocat/__init__.py
@@ -19,7 +19,7 @@ from meteocatpy.town import MeteocatTown
 from meteocatpy.symbols import MeteocatSymbols
 from meteocatpy.variables import MeteocatVariables
 from meteocatpy.townstations import MeteocatTownStations
-from .const import DOMAIN, PLATFORMS
+from .const import DOMAIN, PLATFORMS, LIMIT_XDDE
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -176,28 +176,40 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         ("alerts_region_coordinator", "MeteocatAlertsRegionCoordinator"),
         ("quotes_coordinator", "MeteocatQuotesCoordinator"),
         ("quotes_file_coordinator", "MeteocatQuotesFileCoordinator"),
-        ("lightning_coordinator", "MeteocatLightningCoordinator"),
-        ("lightning_file_coordinator", "MeteocatLightningFileCoordinator"),
         ("sun_coordinator", "MeteocatSunCoordinator"),
         ("sun_file_coordinator", "MeteocatSunFileCoordinator"),
         ("moon_coordinator", "MeteocatMoonCoordinator"),
         ("moon_file_coordinator", "MeteocatMoonFileCoordinator"),
     ]
 
+    # Add lightning coordinators only  if enabled
+    if entry_data.get(LIMIT_XDDE, 250) > 0:
+        coordinator_configs.extend([
+            ("lightning_coordinator", "MeteocatLightningCoordinator"),
+            ("lightning_file_coordinator", "MeteocatLightningFileCoordinator"),
+        ])
+    else:
+        _LOGGER.debug("Lightning data disabled in configuration (API plan has not XDDE enabled)")
+
     hass.data.setdefault(DOMAIN, {})
     hass.data[DOMAIN][entry.entry_id] = {}
 
-    try:
-        for key, cls_name in coordinator_configs:
+    for key, cls_name in coordinator_configs:
+        try:
             # Importación lazy: importa la clase solo cuando sea necesario
             cls = await hass.async_add_executor_job(_get_coordinator_module, cls_name)
             coordinator = cls(hass=hass, entry_data=entry_data)
             await coordinator.async_config_entry_first_refresh()
             hass.data[DOMAIN][entry.entry_id][key] = coordinator
 
-    except Exception as err:
-        _LOGGER.exception("Error al inicializar los coordinadores: %s", err)
-        return False
+        except Exception as err:
+            _LOGGER.exception("Error initializing coordinator %s: %s", key, err)
+            if key in ["lightning_coordinator", "lightning_file_coordinator"]:
+                coordinator_configs.remove((key, cls_name))
+                _LOGGER.exception("Ignoring XDDE related coordinator %s: %s", key, err)
+                pass
+            else:
+                return False
 
     hass.data[DOMAIN][entry.entry_id].update(entry_data)
 

--- a/custom_components/meteocat/config_flow.py
+++ b/custom_components/meteocat/config_flow.py
@@ -601,7 +601,7 @@ class MeteocatConfigFlow(ConfigFlow, domain=DOMAIN):
         schema = vol.Schema({
             vol.Required(LIMIT_XEMA, default=750): cv.positive_int,
             vol.Required(LIMIT_PREDICCIO, default=100): cv.positive_int,
-            vol.Required(LIMIT_XDDE, default=250): cv.positive_int,
+            vol.Required(LIMIT_XDDE, default=250): vol.All(vol.Coerce(int), vol.Range(min=0)),
             vol.Required(LIMIT_QUOTA, default=300): cv.positive_int,
             vol.Required(LIMIT_BASIC, default=2000): cv.positive_int,
         })

--- a/custom_components/meteocat/coordinator.py
+++ b/custom_components/meteocat/coordinator.py
@@ -2612,13 +2612,13 @@ class MeteocatLightningCoordinator(DataUpdateCoordinator):
             _LOGGER.warning("Timeout al obtener rayos.")
             raise ConfigEntryNotReady from err
         except ForbiddenError as err:
-            _LOGGER.error("Acceso denegado al obtener cuotas de la API de Meteocat: %s", err)
+            _LOGGER.error("Acceso denegado al obtener datos de rayos de la API de Meteocat: %s", err)
             raise ConfigEntryNotReady from err
         except TooManyRequestsError as err:
-            _LOGGER.warning("Límite de solicitudes alcanzado al obtener cuotas de la API de Meteocat: %s", err)
+            _LOGGER.warning("Límite de solicitudes alcanzado al obtener datos de rayos de la API de Meteocat: %s", err)
             raise ConfigEntryNotReady from err
         except (BadRequestError, InternalServerError, UnknownAPIError) as err:
-            _LOGGER.error("Error al obtener cuotas de la API de Meteocat: %s", err)
+            _LOGGER.error("Error al obtener datos de rayos de la API de Meteocat: %s", err)
             raise
         except Exception as err:
             _LOGGER.exception("Error inesperado al obtener rayos (region=%s)", self.region_id)
@@ -2689,13 +2689,13 @@ class MeteocatLightningCoordinator(DataUpdateCoordinator):
             _LOGGER.warning("Tiempo de espera agotado al obtener los datos de rayos de la API de Meteocat.")
             raise ConfigEntryNotReady from err
         except ForbiddenError as err:
-            _LOGGER.error("Acceso denegado al obtener cuotas de la API de Meteocat: %s", err)
+            _LOGGER.error("Acceso denegado al obtener datos de rayos de la API de Meteocat: %s", err)
             raise ConfigEntryNotReady from err
         except TooManyRequestsError as err:
-            _LOGGER.warning("Límite de solicitudes alcanzado al obtener cuotas de la API de Meteocat: %s", err)
+            _LOGGER.warning("Límite de solicitudes alcanzado al obtener datos de rayos de la API de Meteocat: %s", err)
             raise ConfigEntryNotReady from err
         except (BadRequestError, InternalServerError, UnknownAPIError) as err:
-            _LOGGER.error("Error al obtener cuotas de la API de Meteocat: %s", err)
+            _LOGGER.error("Error al obtener datos de rayos de la API de Meteocat: %s", err)
             raise
         except Exception as err:
             _LOGGER.exception("Error al obtener datos de rayos: %s", err)

--- a/custom_components/meteocat/options_flow.py
+++ b/custom_components/meteocat/options_flow.py
@@ -110,11 +110,6 @@ class MeteocatOptionsFlowHandler(OptionsFlow):
                     _LOGGER.error("Error inesperado al validar la nueva API Key: %s", ex)
                     errors["base"] = "unknown"
 
-            # Validar que los límites sean números positivos
-            limits_to_validate = [self.limit_xema, self.limit_prediccio, self.limit_xdde, self.limit_quota, self.limit_basic]
-            if not all(cv.positive_int(limit) for limit in limits_to_validate if limit is not None):
-                errors["base"] = "invalid_limit"
-
             if not errors:
                 # Actualizar la configuración de la entrada con la nueva API Key y límites
                 data_update = {}
@@ -140,14 +135,16 @@ class MeteocatOptionsFlowHandler(OptionsFlow):
 
                 return self.async_create_entry(title="", data={})
 
+        # Validations are performed by the schema
         schema = vol.Schema({
             vol.Required(CONF_API_KEY): str,
-            vol.Required(LIMIT_XEMA, default=self._config_entry.data.get(LIMIT_XEMA)): cv.positive_int,
-            vol.Required(LIMIT_PREDICCIO, default=self._config_entry.data.get(LIMIT_PREDICCIO)): cv.positive_int,
-            vol.Required(LIMIT_XDDE, default=self._config_entry.data.get(LIMIT_XDDE)): cv.positive_int,
-            vol.Required(LIMIT_QUOTA, default=self._config_entry.data.get(LIMIT_QUOTA)): cv.positive_int,
-            vol.Required(LIMIT_BASIC, default=self._config_entry.data.get(LIMIT_BASIC)): cv.positive_int,
+            vol.Required(LIMIT_XEMA, default=self._config_entry.data.get(LIMIT_XEMA)): vol.All(vol.Coerce(int), vol.Range(min=1)),
+            vol.Required(LIMIT_PREDICCIO, default=self._config_entry.data.get(LIMIT_PREDICCIO)): vol.All(vol.Coerce(int), vol.Range(min=1)),
+            vol.Required(LIMIT_XDDE, default=self._config_entry.data.get(LIMIT_XDDE)): cv.positive_int, # Allow [0, inf)
+            vol.Required(LIMIT_QUOTA, default=self._config_entry.data.get(LIMIT_QUOTA)): vol.All(vol.Coerce(int), vol.Range(min=1)),
+            vol.Required(LIMIT_BASIC, default=self._config_entry.data.get(LIMIT_BASIC)): vol.All(vol.Coerce(int), vol.Range(min=1)),
         })
+
         return self.async_show_form(
             step_id="update_api_and_limits", data_schema=schema, errors=errors
         )
@@ -162,11 +159,6 @@ class MeteocatOptionsFlowHandler(OptionsFlow):
             self.limit_xdde = user_input.get(LIMIT_XDDE)
             self.limit_quota = user_input.get(LIMIT_QUOTA)
             self.limit_basic = user_input.get(LIMIT_BASIC)
-
-            # Validar que los límites sean números positivos
-            limits_to_validate = [self.limit_xema, self.limit_prediccio, self.limit_xdde, self.limit_quota, self.limit_basic]
-            if not all(cv.positive_int(limit) for limit in limits_to_validate if limit is not None):
-                errors["base"] = "invalid_limit"
 
             if not errors:
                 self.hass.config_entries.async_update_entry(
@@ -185,13 +177,15 @@ class MeteocatOptionsFlowHandler(OptionsFlow):
 
                 return self.async_create_entry(title="", data={})
 
+        # Validations are performed by the schema
         schema = vol.Schema({
-            vol.Required(LIMIT_XEMA, default=self._config_entry.data.get(LIMIT_XEMA)): cv.positive_int,
-            vol.Required(LIMIT_PREDICCIO, default=self._config_entry.data.get(LIMIT_PREDICCIO)): cv.positive_int,
-            vol.Required(LIMIT_XDDE, default=self._config_entry.data.get(LIMIT_XDDE)): cv.positive_int,
-            vol.Required(LIMIT_QUOTA, default=self._config_entry.data.get(LIMIT_QUOTA)): cv.positive_int,
-            vol.Required(LIMIT_BASIC, default=self._config_entry.data.get(LIMIT_BASIC)): cv.positive_int,
+            vol.Required(LIMIT_XEMA, default=self._config_entry.data.get(LIMIT_XEMA)): vol.All(vol.Coerce(int), vol.Range(min=1)),
+            vol.Required(LIMIT_PREDICCIO, default=self._config_entry.data.get(LIMIT_PREDICCIO)): vol.All(vol.Coerce(int), vol.Range(min=1)),
+            vol.Required(LIMIT_XDDE, default=self._config_entry.data.get(LIMIT_XDDE)): cv.positive_int, # Allow [0, inf)
+            vol.Required(LIMIT_QUOTA, default=self._config_entry.data.get(LIMIT_QUOTA)): vol.All(vol.Coerce(int), vol.Range(min=1)),
+            vol.Required(LIMIT_BASIC, default=self._config_entry.data.get(LIMIT_BASIC)): vol.All(vol.Coerce(int), vol.Range(min=1)),
         })
+
         return self.async_show_form(
             step_id="update_limits_only", data_schema=schema, errors=errors
         )

--- a/custom_components/meteocat/sensor.py
+++ b/custom_components/meteocat/sensor.py
@@ -673,25 +673,38 @@ async def async_setup_entry(hass, entry, async_add_entities: AddEntitiesCallback
     )
 
     # Sensores cuotas
+    QUOTA_KEYS = {
+        QUOTA_PREDICCIO,
+        QUOTA_BASIC,
+        QUOTA_XEMA,
+        QUOTA_QUERIES
+    }
+    
+    # Add XDDE if lightning is enabled
+    if lightning_coordinator and lightning_file_coordinator:
+        quota_keys.add(QUOTA_XDDE)
+
     async_add_entities(
         MeteocatQuotaSensor(quotes_file_coordinator, description, entry_data)
         for description in SENSOR_TYPES
-        if description.key in {QUOTA_XDDE, QUOTA_PREDICCIO, QUOTA_BASIC, QUOTA_XEMA, QUOTA_QUERIES}
+        if description.key in QUOTA_KEYS
     )
 
     # Sensores de estado de rayos
-    async_add_entities(
-        MeteocatLightningStatusSensor(lightning_coordinator, description, entry_data)
-        for description in SENSOR_TYPES
-        if description.key == LIGHTNING_FILE_STATUS
-    )
+    if lightning_coordinator:
+        async_add_entities(
+            MeteocatLightningStatusSensor(lightning_coordinator, description, entry_data)
+            for description in SENSOR_TYPES
+            if description.key == LIGHTNING_FILE_STATUS
+        )
 
     # Sensores de rayos en comarca y municipio
-    async_add_entities(
-        MeteocatLightningSensor(lightning_file_coordinator, description, entry_data)
-        for description in SENSOR_TYPES
-        if description.key in {LIGHTNING_REGION, LIGHTNING_TOWN}
-    )
+    if lightning_file_coordinator:
+        async_add_entities(
+            MeteocatLightningSensor(lightning_file_coordinator, description, entry_data)
+            for description in SENSOR_TYPES
+            if description.key in {LIGHTNING_REGION, LIGHTNING_TOWN}
+        )
 
     # Sensor de estado de archivo de sol
     async_add_entities(

--- a/custom_components/meteocat/strings.json
+++ b/custom_components/meteocat/strings.json
@@ -117,7 +117,7 @@
     }
   },
   "entity": {
-    "sensor": {      
+    "sensor": {
       "wind_speed": {
         "name": "Wind Speed"
       },
@@ -238,7 +238,7 @@
         "name": "Hourly File",
         "state": {
           "updated": "Updated",
-          "obsolete": "Obsolete"      
+          "obsolete": "Obsolete"
         },
         "state_attributes": {
           "update_date": {
@@ -253,7 +253,7 @@
         "name": "Daily File",
         "state": {
           "updated": "Updated",
-          "obsolete": "Obsolete"      
+          "obsolete": "Obsolete"
         },
         "state_attributes": {
           "update_date": {
@@ -268,7 +268,7 @@
         "name": "Uvi File",
         "state": {
           "updated": "Updated",
-          "obsolete": "Obsolete"      
+          "obsolete": "Obsolete"
         },
         "state_attributes": {
           "update_date": {
@@ -283,7 +283,7 @@
         "name": "Station Data File",
         "state": {
           "updated": "Updated",
-          "obsolete": "Obsolete"      
+          "obsolete": "Obsolete"
         },
         "state_attributes": {
           "update_date": {
@@ -298,7 +298,7 @@
         "name": "Alert File",
         "state": {
           "updated": "Updated",
-          "obsolete": "Obsolete"      
+          "obsolete": "Obsolete"
         },
         "state_attributes": {
           "update_date": {
@@ -310,7 +310,7 @@
         "name": "Quota File",
         "state": {
           "updated": "Updated",
-          "obsolete": "Obsolete"      
+          "obsolete": "Obsolete"
         },
         "state_attributes": {
           "update_date": {
@@ -322,7 +322,7 @@
         "name": "Lightning File",
         "state": {
           "updated": "Updated",
-          "obsolete": "Obsolete"      
+          "obsolete": "Obsolete"
         },
         "state_attributes": {
           "update_date": {
@@ -363,7 +363,7 @@
         "state": {
           "ok": "Ok",
           "exceeded": "Exceeded",
-          "unknown": "Unknown"      
+          "unknown": "Unknown"
         },
         "state_attributes": {
           "period": {
@@ -390,7 +390,7 @@
         "state": {
           "ok": "Ok",
           "exceeded": "Exceeded",
-          "unknown": "Unknown"      
+          "unknown": "Unknown"
         },
         "state_attributes": {
           "period": {
@@ -417,7 +417,7 @@
         "state": {
           "ok": "Ok",
           "exceeded": "Exceeded",
-          "unknown": "Unknown"      
+          "unknown": "Unknown"
         },
         "state_attributes": {
           "period": {
@@ -444,7 +444,7 @@
         "state": {
           "ok": "Ok",
           "exceeded": "Exceeded",
-          "unknown": "Unknown"      
+          "unknown": "Unknown"
         },
         "state_attributes": {
           "period": {
@@ -471,7 +471,7 @@
         "state": {
           "ok": "Ok",
           "exceeded": "Exceeded",
-          "unknown": "Unknown"      
+          "unknown": "Unknown"
         },
         "state_attributes": {
           "period": {
@@ -572,7 +572,7 @@
         "name": "Alert Wind",
         "state": {
           "opened": "Opened",
-          "closed": "Closed"      
+          "closed": "Closed"
         },
         "state_attributes": {
           "inicio": {
@@ -616,7 +616,7 @@
         "name": "Alert Rain Intensity",
         "state": {
           "opened": "Opened",
-          "closed": "Closed"      
+          "closed": "Closed"
         },
         "state_attributes": {
           "inicio": {
@@ -656,7 +656,7 @@
         "name": "Alert Rain",
         "state": {
           "opened": "Opened",
-          "closed": "Closed"      
+          "closed": "Closed"
         },
         "state_attributes": {
           "inicio": {
@@ -695,7 +695,7 @@
         "name": "Alert Sea",
         "state": {
           "opened": "Opened",
-          "closed": "Closed"      
+          "closed": "Closed"
         },
         "state_attributes": {
           "inicio": {
@@ -735,7 +735,7 @@
         "name": "Alert Cold",
         "state": {
           "opened": "Opened",
-          "closed": "Closed"      
+          "closed": "Closed"
         },
         "state_attributes": {
           "inicio": {
@@ -773,7 +773,7 @@
         "name": "Alert Warm",
         "state": {
           "opened": "Opened",
-          "closed": "Closed"      
+          "closed": "Closed"
         },
         "state_attributes": {
           "inicio": {
@@ -811,7 +811,7 @@
         "name": "Alert Warm Night",
         "state": {
           "opened": "Opened",
-          "closed": "Closed"      
+          "closed": "Closed"
         },
         "state_attributes": {
           "inicio": {
@@ -849,7 +849,7 @@
         "name": "Alert Snow",
         "state": {
           "opened": "Opened",
-          "closed": "Closed"      
+          "closed": "Closed"
         },
         "state_attributes": {
           "inicio": {
@@ -1005,7 +1005,7 @@
         "name": "Sun File",
         "state": {
           "updated": "Updated",
-          "obsolete": "Obsolete"      
+          "obsolete": "Obsolete"
         },
         "state_attributes": {
           "update_date": {

--- a/custom_components/meteocat/translations/ca.json
+++ b/custom_components/meteocat/translations/ca.json
@@ -21,7 +21,14 @@
       },
       "set_api_limits": {
         "description": "Defineix els límits del pla de l'API.",
-        "title": "Límits de l'API"
+        "title": "Límits de l'API",
+        "data": {
+          "limit_xema": "Límit XEMA (Xarxa d'Estacions Meteorològiques Automàtiques)",
+          "limit_prediccio": "Límit Predicció",
+          "limit_xdde": "Límit XDDE (Xarxa de Detecció de Descàrregues Elèctriques) (0 per desactivar)",
+          "limit_quota": "Límit Quota",
+          "limit_basic": "Límit Basic"
+        }
       }
     },
     "error": {
@@ -34,7 +41,7 @@
     }
   },
   "options": {
-    "step":{
+    "step": {
       "init": {
         "description": "Configureu la clau API, els límits de l'API, regenereu els fitxers d'assets, actualitzeu coordenades o forceu l'actualització de dades.",
         "title": "Opcions de configuració",
@@ -44,11 +51,25 @@
       },
       "update_api_and_limits": {
         "description": "Configura l'API Key i els límits de l'API.",
-        "title": "API Key i límits"
+        "title": "API Key i límits",
+        "data": {
+          "limit_xema": "Límit XEMA (Xarxa d'Estacions Meteorològiques Automàtiques)",
+          "limit_prediccio": "Límit Predicció",
+          "limit_xdde": "Límit XDDE (Xarxa de Detecció de Descàrregues Elèctriques) (0 per desactivar)",
+          "limit_quota": "Límit Quota",
+          "limit_basic": "Límit Basic"
+        }
       },
       "update_limits_only": {
         "description": "Configura els límits de l'API.",
-        "title": "Límits de l'API"
+        "title": "Límits de l'API",
+        "data": {
+          "limit_xema": "Límit XEMA (Xarxa d'Estacions Meteorològiques Automàtiques)",
+          "limit_prediccio": "Límit Predicció",
+          "limit_xdde": "Límit XDDE (Xarxa de Detecció de Descàrregues Elèctriques) (0 per desactivar)",
+          "limit_quota": "Límit Quota",
+          "limit_basic": "Límit Basic"
+        }
       },
       "update_coordinates": {
         "description": "Introduïu noves coordenades. Coordenades actuals: latitud {current_latitude}, longitud {current_longitude}. Altitud actual: {current_altitude} metres.",
@@ -117,7 +138,7 @@
     }
   },
   "entity": {
-    "sensor": {      
+    "sensor": {
       "wind_speed": {
         "name": "Vent Velocitat"
       },
@@ -238,7 +259,7 @@
         "name": "Arxiu Horari",
         "state": {
           "updated": "Actualitzat",
-          "obsolete": "Obsolet"      
+          "obsolete": "Obsolet"
         },
         "state_attributes": {
           "update_date": {
@@ -253,7 +274,7 @@
         "name": "Arxiu Diari",
         "state": {
           "updated": "Actualitzat",
-          "obsolete": "Obsolet"      
+          "obsolete": "Obsolet"
         },
         "state_attributes": {
           "update_date": {
@@ -268,7 +289,7 @@
         "name": "Arxiu UVI",
         "state": {
           "updated": "Actualitzat",
-          "obsolete": "Obsolet"      
+          "obsolete": "Obsolet"
         },
         "state_attributes": {
           "update_date": {
@@ -283,7 +304,7 @@
         "name": "Arxiu Estació",
         "state": {
           "updated": "Actualitzat",
-          "obsolete": "Obsolet"      
+          "obsolete": "Obsolet"
         },
         "state_attributes": {
           "update_date": {
@@ -298,7 +319,7 @@
         "name": "Arxiu Alerta",
         "state": {
           "updated": "Actualitzat",
-          "obsolete": "Obsolet"      
+          "obsolete": "Obsolet"
         },
         "state_attributes": {
           "update_date": {
@@ -310,7 +331,7 @@
         "name": "Arxiu Quota",
         "state": {
           "updated": "Actualitzat",
-          "obsolete": "Obsolet"      
+          "obsolete": "Obsolet"
         },
         "state_attributes": {
           "update_date": {
@@ -322,7 +343,7 @@
         "name": "Arxiu Llamps",
         "state": {
           "updated": "Actualitzat",
-          "obsolete": "Obsolet"      
+          "obsolete": "Obsolet"
         },
         "state_attributes": {
           "update_date": {
@@ -336,7 +357,7 @@
           "cloud_cloud": {
             "name": "Núvol-Núvol"
           },
-          "cloud_ground_neg":{
+          "cloud_ground_neg": {
             "name": "Núvol-Terra Negatiu"
           },
           "cloud_ground_pos": {
@@ -350,7 +371,7 @@
           "cloud_cloud": {
             "name": "Núvol-Núvol"
           },
-          "cloud_ground_neg":{
+          "cloud_ground_neg": {
             "name": "Núvol-Terra Negatiu"
           },
           "cloud_ground_pos": {
@@ -363,7 +384,7 @@
         "state": {
           "ok": "Ok",
           "exceeded": "Superada",
-          "unknown": "Desconegut"      
+          "unknown": "Desconegut"
         },
         "state_attributes": {
           "period": {
@@ -390,7 +411,7 @@
         "state": {
           "ok": "Ok",
           "exceeded": "Superada",
-          "unknown": "Desconegut"      
+          "unknown": "Desconegut"
         },
         "state_attributes": {
           "period": {
@@ -417,7 +438,7 @@
         "state": {
           "ok": "Ok",
           "exceeded": "Superada",
-          "unknown": "Desconegut"      
+          "unknown": "Desconegut"
         },
         "state_attributes": {
           "period": {
@@ -444,7 +465,7 @@
         "state": {
           "ok": "Ok",
           "exceeded": "Superada",
-          "unknown": "Desconegut"      
+          "unknown": "Desconegut"
         },
         "state_attributes": {
           "period": {
@@ -471,7 +492,7 @@
         "state": {
           "ok": "Ok",
           "exceeded": "Superada",
-          "unknown": "Desconegut"      
+          "unknown": "Desconegut"
         },
         "state_attributes": {
           "period": {
@@ -572,7 +593,7 @@
         "name": "Alerta Vent",
         "state": {
           "opened": "Obert",
-          "closed": "Tancat"      
+          "closed": "Tancat"
         },
         "state_attributes": {
           "inicio": {
@@ -616,7 +637,7 @@
         "name": "Alerta Intensitat de Pluja",
         "state": {
           "opened": "Obert",
-          "closed": "Tancat"      
+          "closed": "Tancat"
         },
         "state_attributes": {
           "inicio": {
@@ -656,7 +677,7 @@
         "name": "Alerta Pluja",
         "state": {
           "opened": "Obert",
-          "closed": "Tancat"      
+          "closed": "Tancat"
         },
         "state_attributes": {
           "inicio": {
@@ -695,7 +716,7 @@
         "name": "Alerta Mar",
         "state": {
           "opened": "Obert",
-          "closed": "Tancat"      
+          "closed": "Tancat"
         },
         "state_attributes": {
           "inicio": {
@@ -735,7 +756,7 @@
         "name": "Alerta Fred",
         "state": {
           "opened": "Obert",
-          "closed": "Tancat"      
+          "closed": "Tancat"
         },
         "state_attributes": {
           "inicio": {
@@ -773,7 +794,7 @@
         "name": "Alerta Calor",
         "state": {
           "opened": "Obert",
-          "closed": "Tancat"      
+          "closed": "Tancat"
         },
         "state_attributes": {
           "inicio": {
@@ -811,7 +832,7 @@
         "name": "Alerta Calor Nocturna",
         "state": {
           "opened": "Obert",
-          "closed": "Tancat"      
+          "closed": "Tancat"
         },
         "state_attributes": {
           "inicio": {
@@ -849,7 +870,7 @@
         "name": "Alerta Neu",
         "state": {
           "opened": "Obert",
-          "closed": "Tancat"      
+          "closed": "Tancat"
         },
         "state_attributes": {
           "inicio": {
@@ -1005,7 +1026,7 @@
         "name": "Arxiu Sol",
         "state": {
           "updated": "Actualitzat",
-          "obsolete": "Obsolet"      
+          "obsolete": "Obsolet"
         },
         "state_attributes": {
           "update_date": {

--- a/custom_components/meteocat/translations/en.json
+++ b/custom_components/meteocat/translations/en.json
@@ -21,7 +21,14 @@
       },
       "set_api_limits": {
         "description": "Set the API limits.",
-        "title": "API limits"
+        "title": "API limits",
+        "data": {
+          "limit_xema": "XEMA Limit (Automatic Meteorological Stations Network)",
+          "limit_prediccio": "Prediction Limit",
+          "limit_xdde": "XDDE Limit (Lightning Detection Network) (0 to disable)",
+          "limit_quota": "Quota Limit",
+          "limit_basic": "Basic Limit"
+        }
       }
     },
     "error": {
@@ -44,11 +51,25 @@
       },
       "update_api_and_limits": {
         "description": "Setup the API Key and the API limits.",
-        "title": "API Key and limits"
+        "title": "API Key and limits",
+        "data": {
+          "limit_xema": "XEMA Limit (Automatic Meteorological Stations Network)",
+          "limit_prediccio": "Prediction Limit",
+          "limit_xdde": "XDDE Limit (Lightning Detection Network) (0 to disable)",
+          "limit_quota": "Quota Limit",
+          "limit_basic": "Basic Limit"
+        }
       },
       "update_limits_only": {
         "description": "Setup the API limits.",
-        "title": "API limits"
+        "title": "API limits",
+        "data": {
+          "limit_xema": "XEMA Limit (Automatic Meteorological Stations Network)",
+          "limit_prediccio": "Prediction Limit",
+          "limit_xdde": "XDDE Limit (Lightning Detection Network) (0 to disable)",
+          "limit_quota": "Quota Limit",
+          "limit_basic": "Basic Limit"
+        }
       },
       "update_coordinates": {
         "description": "Enter new coordinates. Current coordinates: latitude {current_latitude}, longitude {current_longitude}. Current altitude: {current_altitude} meters.",

--- a/custom_components/meteocat/translations/es.json
+++ b/custom_components/meteocat/translations/es.json
@@ -21,7 +21,14 @@
       },
       "set_api_limits": {
         "description": "Define los límites del plan de la API.",
-        "title": "API límites"
+        "title": "Límites de la API",
+        "data": {
+          "limit_xema": "Límite XEMA (Red de Estaciones Meteorológicas Automáticas)",
+          "limit_prediccio": "Límite Predicción",
+          "limit_xdde": "Límite XDDE (Red de Detección de Descargas Eléctricas) (0 para desactivar)",
+          "limit_quota": "Límite Quota",
+          "limit_basic": "Límite Básico"
+        }
       }
     },
     "error": {
@@ -44,11 +51,25 @@
       },
       "update_api_and_limits": {
         "description": "Configura el API Key y los límites de la API.",
-        "title": "API Key y límites"
+        "title": "API Key y límites",
+        "data": {
+          "limit_xema": "Límite XEMA (Red de Estaciones Meteorológicas Automáticas)",
+          "limit_prediccio": "Límite Predicción",
+          "limit_xdde": "Límite XDDE (Red de Detección de Descargas Eléctricas) (0 para desactivar)",
+          "limit_quota": "Límite Quota",
+          "limit_basic": "Límite Básico"
+        }
       },
       "update_limits_only": {
         "description": "Configura los límites de la API.",
-        "title": "Límites de la API"
+        "title": "Límites de la API",
+        "data": {
+          "limit_xema": "Límite XEMA (Red de Estaciones Meteorológicas Automáticas)",
+          "limit_prediccio": "Límite Predicción",
+          "limit_xdde": "Límite XDDE (Red de Detección de Descargas Eléctricas) (0 para desactivar)",
+          "limit_quota": "Límite Quota",
+          "limit_basic": "Límite Básico"
+        }
       },
       "update_coordinates": {
         "description": "Introduce nuevas coordenadas. Coordenadas actuales: latitud {current_latitude}, longitud {current_longitude}. Altitud actual: {current_altitude} metros.",


### PR DESCRIPTION
As XDDE plan is optional when requesting API token and it's not required by the basic usage of meteo data (temperature, forecast...).

I've added the option to set LIMIT_XDDE to 0 to disable loading Lightning coordinators